### PR TITLE
release v0.2.0

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -32,5 +32,6 @@ jobs:
           printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
           gem build *.gemspec
           gem push *.gem
+        continue-on-error: true
         env:
           GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.0
+
+- rename `OmniAuth::TimeTree` module from `Omniauth::Timetree`.
+- improve tests with Rack::Test.
+- do refactor.
+
 # 0.1.3
 
 - refs #1 setup GitHub Actions for rspec and pushing to RubyGems.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OmniAuth::Timetree
+# OmniAuth::TimeTree
 
 [![Test](https://github.com/koshilife/omniauth-timetree/workflows/Test/badge.svg)](https://github.com/koshilife/omniauth-timetree/actions?query=workflow%3ATest)
 [![codecov](https://codecov.io/gh/koshilife/omniauth-timetree/branch/master/graph/badge.svg)](https://codecov.io/gh/koshilife/omniauth-timetree)

--- a/lib/omniauth-timetree/version.rb
+++ b/lib/omniauth-timetree/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Omniauth
-  module Timetree
+module OmniAuth
+  module TimeTree
     VERSION = '0.1.4'
   end
 end

--- a/lib/omniauth/strategies/timetree.rb
+++ b/lib/omniauth/strategies/timetree.rb
@@ -4,24 +4,24 @@ require 'omniauth-oauth2'
 
 module OmniAuth
   module Strategies
-    class Timetree < OmniAuth::Strategies::OAuth2
+    class TimeTree < OmniAuth::Strategies::OAuth2
       option :name, 'timetree'
       option :client_options, :site => 'https://timetreeapp.com'
 
-      uid { raw_info[:id] }
+      uid { raw_info['id'] }
 
       extra do
         {:raw_info => raw_info}
       end
 
+    private
+
       def raw_info
-        return @raw_info unless @raw_info.nil?
+        return @raw_info if defined?(@raw_info)
 
         endpoint = 'https://timetreeapis.com/user'
         options = {:headers => {'Accept' => 'application/vnd.timetree.v1+json'}}
-        res = access_token.get(endpoint, options)
-        parsed_body = JSON.parse(res.body, :symbolize_names => true)
-        @raw_info = parsed_body[:data] || {}
+        @raw_info = access_token.get(endpoint, options).parsed
       end
 
       def callback_url

--- a/omniauth-timetree.gemspec
+++ b/omniauth-timetree.gemspec
@@ -4,7 +4,7 @@ require_relative 'lib/omniauth-timetree/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'omniauth-timetree'
-  spec.version       = Omniauth::Timetree::VERSION
+  spec.version       = OmniAuth::TimeTree::VERSION
   spec.authors       = ['Kenji Koshikawa']
   spec.email         = ['koshikawa2009@gmail.com']
 
@@ -32,7 +32,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'codecov', '~> 0.1.17'
+  spec.add_development_dependency 'omniauth', '~> 1.9.1'
+  spec.add_development_dependency 'rack-test', '~> 1.1.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.18.5'
+  spec.add_development_dependency 'webmock', '~> 3.7.6'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,6 @@ if ENV['CI'] == 'true'
 end
 
 require 'omniauth-timetree'
+require 'omniauth'
+require 'rack/test'
+require 'webmock/rspec'


### PR DESCRIPTION
- do refactor.
- rename `OmniAuth::TimeTree` module from `Omniauth::Timetree`.
- improve tests with Rack::Test.
- update gem-push GitHub Actions settings in order to ignore error for same version.
