### PR TITLE
release 1.0.0 - allow for omniauth 2.0 series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.0
+
+- refs #12 allowed for omniauth 2.0 series.
+
 ## 0.4.0
 
 - fix #13 set uid field.

--- a/lib/omniauth-timetree/version.rb
+++ b/lib/omniauth-timetree/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module TimeTree
-    VERSION = '0.4.0'
+    VERSION = '1.0.0'
   end
 end

--- a/lib/omniauth/strategies/timetree.rb
+++ b/lib/omniauth/strategies/timetree.rb
@@ -29,7 +29,7 @@ module OmniAuth
       end
 
       def callback_url
-        full_host + script_name + callback_path
+        full_host + callback_path
       end
     end
   end

--- a/lib/omniauth/strategies/timetree.rb
+++ b/lib/omniauth/strategies/timetree.rb
@@ -8,7 +8,7 @@ module OmniAuth
       option :name, 'timetree'
       option :client_options, site: 'https://timetreeapp.com'
 
-      uid { extract_uid }
+      uid { raw_info.dig('data', 'id') }
 
       extra do
         {raw_info: raw_info}
@@ -22,10 +22,6 @@ module OmniAuth
         endpoint = 'https://timetreeapis.com/user'
         options = {headers: {'Accept' => 'application/vnd.timetree.v1+json'}}
         @raw_info = access_token.get(endpoint, options).parsed
-      end
-
-      def extract_uid
-        raw_info.dig('data', 'id')
       end
 
       def callback_url

--- a/omniauth-timetree.gemspec
+++ b/omniauth-timetree.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'omniauth', '~> 1.9'
-  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.6.0'
+  spec.add_runtime_dependency 'omniauth', '~> 2.0'
+  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.7.1'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'codecov'


### PR DESCRIPTION
refs #12

This PR allow for omniauth 2.0.
Could you merge #14 PR first in order to avoid library dependency problem?
PR #14 make dependency specified for omniauth 1.9.